### PR TITLE
Adjust deployment api from apps/v1beta1 to apps/v1

### DIFF
--- a/charts/azure-voting-app/templates/azure-vote-back-deployment.yaml
+++ b/charts/azure-voting-app/templates/azure-vote-back-deployment.yaml
@@ -1,5 +1,5 @@
 {{- $serviceName := include "name" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1
 kind: Deployment
 metadata:
   name: {{ $serviceName }}-{{ .Values.azureVoteBack.deployment.name }}

--- a/charts/azure-voting-app/templates/azure-vote-back-deployment.yaml
+++ b/charts/azure-voting-app/templates/azure-vote-back-deployment.yaml
@@ -1,5 +1,5 @@
 {{- $serviceName := include "name" . -}}
-apiVersion: extensions/v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $serviceName }}-{{ .Values.azureVoteBack.deployment.name }}
@@ -7,6 +7,10 @@ metadata:
 {{ include "labels.standard" . | indent 4 }}
     component: {{ $serviceName }}-{{ .Values.azureVoteBack.deployment.name }}
 spec:
+  selector:
+    matchLabels:
+{{ include "labels.standard" . | indent 8 }}
+        component: {{ $serviceName }}-{{ .Values.azureVoteBack.deployment.name }}
   replicas: {{ .Values.azureVoteBack.deployment.replicas }}
   template:
     metadata:

--- a/charts/azure-voting-app/templates/azure-vote-front-deployment.yaml
+++ b/charts/azure-voting-app/templates/azure-vote-front-deployment.yaml
@@ -1,5 +1,5 @@
 {{- $serviceName := include "name" . -}}
-apiVersion: extensions/v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $serviceName }}-{{ .Values.azureVoteFront.deployment.name }}
@@ -7,6 +7,10 @@ metadata:
 {{ include "labels.standard" . | indent 4 }}
     component: {{ $serviceName }}-{{ .Values.azureVoteFront.deployment.name }}
 spec:
+  selector:
+    matchLabels:
+{{ include "labels.standard" . | indent 8 }}
+        component: {{ $serviceName }}-{{ .Values.azureVoteBack.deployment.name }}
   replicas: {{ .Values.azureVoteFront.deployment.replicas }}
   strategy:
     rollingUpdate:

--- a/charts/azure-voting-app/templates/azure-vote-front-deployment.yaml
+++ b/charts/azure-voting-app/templates/azure-vote-front-deployment.yaml
@@ -1,5 +1,5 @@
 {{- $serviceName := include "name" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1
 kind: Deployment
 metadata:
   name: {{ $serviceName }}-{{ .Values.azureVoteFront.deployment.name }}

--- a/kubernetes-manifests/azure-vote-all-in-one.yaml
+++ b/kubernetes-manifests/azure-vote-all-in-one.yaml
@@ -35,6 +35,9 @@ kind: Deployment
 metadata:
   name: azure-vote-back
 spec:
+  selector:
+    matchLabels:
+      app: azure-vote-back
   replicas: 1
   template:
     metadata:
@@ -92,6 +95,9 @@ kind: Deployment
 metadata:
   name: azure-vote-front
 spec:
+  selector:
+    matchLabels:
+      app: azure-vote-front
   replicas: 1
   strategy:
     rollingUpdate:

--- a/kubernetes-manifests/azure-vote-all-in-one.yaml
+++ b/kubernetes-manifests/azure-vote-all-in-one.yaml
@@ -30,7 +30,7 @@ data:
   MYSQL_HOST: YXp1cmUtdm90ZS1iYWNr
   MYSQL_ROOT_PASSWORD: UGFzc3dvcmQxMg==
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: azure-vote-back
@@ -87,7 +87,7 @@ spec:
   selector:
     app: azure-vote-back
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: azure-vote-front
@@ -97,7 +97,7 @@ spec:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 1
-  minReadySeconds: 5 
+  minReadySeconds: 5
   template:
     metadata:
       labels:

--- a/kubernetes-manifests/azure-vote-deployment.yaml
+++ b/kubernetes-manifests/azure-vote-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: azure-vote-back
@@ -45,7 +45,7 @@ spec:
         persistentVolumeClaim:
           claimName: mysql-pv-claim
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: azure-vote-front
@@ -55,7 +55,7 @@ spec:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 1
-  minReadySeconds: 5 
+  minReadySeconds: 5
   template:
     metadata:
       labels:


### PR DESCRIPTION
This PR:

- Adjusts the deployment api version to apps/v1
- Removes a couple of trailing spaces
- Adds missing selectors in the deployment manifests and chart